### PR TITLE
Add secrets support

### DIFF
--- a/install/etc/cont-init.d/30-fusiondirectory
+++ b/install/etc/cont-init.d/30-fusiondirectory
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 function file_env () {
   local var="$1"
   local fileVar="${var}_FILE"

--- a/install/etc/cont-init.d/30-fusiondirectory
+++ b/install/etc/cont-init.d/30-fusiondirectory
@@ -6,12 +6,12 @@ function file_env () {
   local def="${2:-}"
   local val="$def"
   if [ "${!fileVar:-}" ]; then
-    val="$(<"${!fileVar}")"
+    val="$(cat "${!fileVar}")"
   elif [ "${!var:-}" ]; then
     val="${!var}"
   fi
   if [ -z ${val} ]; then
-    echo >&2 "error: neither $var nor $fileVar are set but are required"
+    print_error "error: neither $var nor $fileVar are set but are required"
     exit 1
   fi
   export "$var"="$val"

--- a/install/etc/cont-init.d/30-fusiondirectory
+++ b/install/etc/cont-init.d/30-fusiondirectory
@@ -339,6 +339,7 @@ tar cfz fusiondirectory-plugins.tar.gz ./fusiondirectory-plugins
 echo '/assets/fusiondirectory-plugins.tar.gz' | fusiondirectory-setup --set-fd_home=${NGINX_WEBROOT} --write-vars --install-plugins --check-directories --update-locales --update-cache  >/dev/null
 rm -rf /assets/fusiondirectory-plugins.tar.gz /assets/fusiondirectory-plugins /tmp/fusiondirectory-plugins
 
+file_env 'LDAP1_ADMIN_PASS'
 ### Configuration File Building
 if [ -z ${LDAP1_BASE_DN} ] ; then printf "\n\nLDAP1_BASE_DN is not defined!\n"; exit 1; fi;
 if [ -z ${LDAP1_HOST} ] ; then printf "\n\nLDAP1_HOST is not defined!\n"; exit 1; fi;
@@ -364,6 +365,7 @@ EOF
   do
 
       LDAP_HOST=LDAP${i}_HOST
+      file_env "LDAP${i}_ADMIN_PASS"
       LDAP_ADMIN_PASS=LDAP${i}_ADMIN_PASS
       LDAP_ADMIN_DN=LDAP${i}_ADMIN_DN
       LDAP_BASE_DN=LDAP${i}_BASE_DN
@@ -371,7 +373,6 @@ EOF
       LDAP_TLS=LDAP${i}_TLS
       LDAP_PORT=LDAP${i}_PORT
       
-      file_env 'LDAP_ADMIN_PASS'
 
       if [ "${!LDAP_TLS}" = "TRUE" ] ; then
           LDAP_SCHEME="ldaps"

--- a/install/etc/cont-init.d/30-fusiondirectory
+++ b/install/etc/cont-init.d/30-fusiondirectory
@@ -1,22 +1,22 @@
 #!/usr/bin/with-contenv bash
 
 function file_env () {
-		local var="$1"
-		local fileVar="${var}_FILE"
-		local def="${2:-}"
-		local val="$def"
-		if [ "${!fileVar:-}" ]; then
-			val="$(<"${!fileVar}")"
-		elif [ "${!var:-}" ]; then
-			val="${!var}"
-		fi
-		if [ -z ${val} ]; then
-			echo >&2 "error: neither $var nor $fileVar are set but are required"
-			exit 1
-		fi
-		export "$var"="$val"
-		unset "$fileVar"
-	}
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  local val="$def"
+  if [ "${!fileVar:-}" ]; then
+    val="$(<"${!fileVar}")"
+  elif [ "${!var:-}" ]; then
+    val="${!var}"
+  fi
+  if [ -z ${val} ]; then
+    echo >&2 "error: neither $var nor $fileVar are set but are required"
+    exit 1
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
 
 for s in /assets/functions/*; do source $s; done
 PROCESS_NAME="fusiondirectory"

--- a/install/etc/cont-init.d/30-fusiondirectory
+++ b/install/etc/cont-init.d/30-fusiondirectory
@@ -1,5 +1,23 @@
 #!/usr/bin/with-contenv bash
 
+function file_env () {
+		local var="$1"
+		local fileVar="${var}_FILE"
+		local def="${2:-}"
+		local val="$def"
+		if [ "${!fileVar:-}" ]; then
+			val="$(<"${!fileVar}")"
+		elif [ "${!var:-}" ]; then
+			val="${!var}"
+		fi
+		if [ -z ${val} ]; then
+			echo >&2 "error: neither $var nor $fileVar are set but are required"
+			exit 1
+		fi
+		export "$var"="$val"
+		unset "$fileVar"
+	}
+
 for s in /assets/functions/*; do source $s; done
 PROCESS_NAME="fusiondirectory"
 
@@ -352,6 +370,8 @@ EOF
       LDAP_NAME=LDAP${i}_NAME
       LDAP_TLS=LDAP${i}_TLS
       LDAP_PORT=LDAP${i}_PORT
+      
+      file_env 'LDAP_ADMIN_PASS'
 
       if [ "${!LDAP_TLS}" = "TRUE" ] ; then
           LDAP_SCHEME="ldaps"


### PR DESCRIPTION
This change adds a file_env function which supports reading passwords from files.

It enables using [secrets](https://docs.docker.com/engine/swarm/secrets/) from docker swarm.